### PR TITLE
 feat : use --no-cache-dir flag to pip in dockerfiles to save space

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,9 +27,9 @@ ENV PATH /opt/conda/bin:$PATH
 
 RUN conda install -c pytorch pytorch=0.4.1 cuda90
 
-RUN pip install --upgrade pip
-RUN pip install tqdm==4.9.0 &&\
-     pip install matplotlib==2.1.2
+RUN pip install --no-cache-dir --upgrade pip
+RUN pip install --no-cache-dir tqdm==4.9.0 &&\
+     pip install --no-cache-dir matplotlib==2.1.2
 
 WORKDIR /workspace
 RUN mkdir MultiHopKG


### PR DESCRIPTION
using the "--no-cache-dir" flag in pip install, make sure downloaded packages by pip don't cache on the system. This is a best practice that makes sure to fetch from a repo instead of using a local cached one. Further, in the case of Docker Containers, by restricting caching, we can reduce image size. In terms of stats, it depends upon the number of python packages multiplied by their respective size. e.g for heavy packages with a lot of dependencies it reduces a lot by don't cache pip packages.

Further, more detailed information can be found at

https://medium.com/sciforce/strategies-of-docker-images-optimization-2ca9cc5719b6